### PR TITLE
ignore `dockerfile` and `gomod` manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,8 @@
       "depNameTemplate": "github.com/golangci/golangci-lint",
       "datasourceTemplate": "go"
     }
-  ]
+  ],
+  "dockerfile": {
+    "enabled": false
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,8 @@
   ],
   "dockerfile": {
     "enabled": false
+  },
+  "gomod": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
I want Renovate to manage only `regexManagers`, so I have the other managers ignored.
ref. https://docs.renovatebot.com/modules/manager/#enabling-and-disabling-managers